### PR TITLE
add null distribution as key to p_value method metadata

### DIFF
--- a/mgcpy/independence_tests/abstract_class.py
+++ b/mgcpy/independence_tests/abstract_class.py
@@ -113,7 +113,8 @@ class IndependenceTest(ABC):
                 p_value = t.cdf(T, df=df)
             else:
                 p_value = 1 - t.cdf(T, df=df)
-            p_value_metadata = {tuple(null_distribution)}
+            p_value_metadata = {"test_statistic": test_statistic,
+                                "null_distribution": null_distribution}
         elif self.get_name() == "mgc":
             local_correlation_matrix = independence_test_metadata["local_correlation_matrix"]
 
@@ -157,7 +158,8 @@ class IndependenceTest(ABC):
                 test_stats_null[rep], _ = self.test_statistic(matrix_X=matrix_X, matrix_Y=permuted_y)
             # p-value is the probability of observing more extreme test statistic under the null
             p_value = np.where(test_stats_null >= test_statistic)[0].shape[0] / replication_factor
-            p_value_metadata = {tuple(test_stats_null)}
+            p_value_metadata = {"test_statistic": test_statistic,
+                                "null_distribution": test_statis_null}
 
         # Correct for a p_value of 0. This is because, with bootstrapping permutations, a value of 0 is not valid
         if p_value == 0:

--- a/mgcpy/independence_tests/abstract_class.py
+++ b/mgcpy/independence_tests/abstract_class.py
@@ -2,7 +2,6 @@
     **Main Independence Test Abstract Class**
 """
 import time
-import warnings
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -159,11 +158,6 @@ class IndependenceTest(ABC):
             # p-value is the probability of observing more extreme test statistic under the null
             p_value = np.where(test_stats_null >= test_statistic)[0].shape[0] / replication_factor
             p_value_metadata = {tuple(test_stats_null)}
-
-        # The results are not statistically significant
-        if p_value > 0.05:
-            warnings.warn("The p-value is greater than 0.05, implying that the results are not statistically significant.\n" +
-                          "Use results such as test_statistic and optimal_scale, with caution!")
 
         self.p_value_ = p_value
         self.p_value_metadata_ = p_value_metadata

--- a/mgcpy/independence_tests/abstract_class.py
+++ b/mgcpy/independence_tests/abstract_class.py
@@ -98,6 +98,15 @@ class IndependenceTest(ABC):
             "The distance correlation t-test of independence in high dimension."
             Journal of Multivariate Analysis 117 (2013): 193-213.
             '''
+            null_distribution = []
+            for _ in range(replication_factor):
+                # use random permutations on the second data set
+                premuted_matrix_Y = np.random.permutation(matrix_Y)
+
+                temp_mgc_statistic, temp_independence_test_metadata = self.test_statistic(
+                    matrix_X, premuted_matrix_Y)
+                null_distribution.append(temp_mgc_statistic)
+
             T, df = self.unbiased_T(matrix_X=matrix_X, matrix_Y=matrix_Y)
             # p-value is the probability of obtaining values more extreme than the test statistic
             # under the null
@@ -105,7 +114,7 @@ class IndependenceTest(ABC):
                 p_value = t.cdf(T, df=df)
             else:
                 p_value = 1 - t.cdf(T, df=df)
-            p_value_metadata = {}
+            p_value_metadata = {tuple(null_distribution)}
         elif self.get_name() == "mgc":
             local_correlation_matrix = independence_test_metadata["local_correlation_matrix"]
 
@@ -113,12 +122,14 @@ class IndependenceTest(ABC):
             p_value = 0
 
             # compute sample MGC statistic and all local correlations for each set of permuted data
+            null_distribution = []
             for _ in range(replication_factor):
                 # use random permutations on the second data set
                 premuted_matrix_Y = np.random.permutation(matrix_Y)
 
                 temp_mgc_statistic, temp_independence_test_metadata = self.test_statistic(
                     matrix_X, premuted_matrix_Y)
+                null_distribution.append(temp_mgc_statistic)
                 temp_local_correlation_matrix = temp_independence_test_metadata["local_correlation_matrix"]
 
                 p_value += ((temp_mgc_statistic >= test_statistic) * (1/replication_factor))
@@ -126,6 +137,7 @@ class IndependenceTest(ABC):
                                                 local_correlation_matrix) * (1/replication_factor))
 
             p_value_metadata = {"test_statistic": test_statistic,
+                                "null_distribution": null_distribution,
                                 "p_local_correlation_matrix": p_local_correlation_matrix,
                                 "local_correlation_matrix": local_correlation_matrix,
                                 "optimal_scale": independence_test_metadata["optimal_scale"]}
@@ -146,7 +158,7 @@ class IndependenceTest(ABC):
                 test_stats_null[rep], _ = self.test_statistic(matrix_X=matrix_X, matrix_Y=permuted_y)
             # p-value is the probability of observing more extreme test statistic under the null
             p_value = np.where(test_stats_null >= test_statistic)[0].shape[0] / replication_factor
-            p_value_metadata = {}
+            p_value_metadata = {tuple(test_stats_null)}
 
         # The results are not statistically significant
         if p_value > 0.05:

--- a/mgcpy/independence_tests/abstract_class.py
+++ b/mgcpy/independence_tests/abstract_class.py
@@ -159,6 +159,9 @@ class IndependenceTest(ABC):
             p_value = np.where(test_stats_null >= test_statistic)[0].shape[0] / replication_factor
             p_value_metadata = {tuple(test_stats_null)}
 
+        # Correct for a p_value of 0. This is because, with bootstrapping permutations, a value of 0 is not valid
+        if p_value == 0:
+            p_value = 1 / replication_factor
         self.p_value_ = p_value
         self.p_value_metadata_ = p_value_metadata
         return p_value, p_value_metadata

--- a/mgcpy/independence_tests/dcorr.py
+++ b/mgcpy/independence_tests/dcorr.py
@@ -264,6 +264,8 @@ class DCorr(IndependenceTest):
 
         if is_fast:
             p_value, p_value_metadata = self._fast_dcorr_p_value(matrix_X, matrix_Y, **fast_dcorr_data)
+            if p_value = 0:
+                p_value = 1 / replication_factor
             self.p_value_ = p_value
             self.p_value_metadata_ = p_value_metadata
             return p_value, p_value_metadata

--- a/mgcpy/independence_tests/dcorr.py
+++ b/mgcpy/independence_tests/dcorr.py
@@ -1,4 +1,3 @@
-import warnings
 from statistics import mean
 
 import numpy as np
@@ -306,11 +305,6 @@ class DCorr(IndependenceTest):
         '''
         test_statistic, test_statistic_metadata = self.test_statistic(matrix_X, matrix_Y, is_fast=True, fast_dcorr_data={"sub_samples": sub_samples})
         p_value = _fast_pvalue(test_statistic, test_statistic_metadata)
-
-        # The results are not statistically significant
-        if p_value > 0.05:
-            warnings.warn("The p-value is greater than 0.05, implying that the results are not statistically significant.\n" +
-                          "Use results such as test_statistic and optimal_scale, with caution!")
 
         p_value_metadata = {"test_statistic": test_statistic}
 

--- a/mgcpy/independence_tests/mgc.py
+++ b/mgcpy/independence_tests/mgc.py
@@ -219,11 +219,13 @@ class MGC(IndependenceTest):
 
         if is_fast:
             p_value, p_value_metadata = self._fast_mgc_p_value(matrix_X, matrix_Y, **fast_mgc_data)
+            if p_value == 0:
+                p_value = 1 / replication_factor
             self.p_value_ = p_value
             self.p_value_metadata_ = p_value_metadata
             return p_value, p_value_metadata
         else:
-            return super(MGC, self).p_value(matrix_X, matrix_Y)
+            return super(MGC, self).p_value(matrix_X, matrix_Y, replication_factor=replication_factor)
 
     def _fast_mgc_p_value(self, matrix_X, matrix_Y, sub_samples=10):
         '''

--- a/mgcpy/independence_tests/mgc.py
+++ b/mgcpy/independence_tests/mgc.py
@@ -1,7 +1,7 @@
 """
     **Main MGC Independence Test Module**
 """
-import warnings
+import logging
 
 from mgcpy.independence_tests.abstract_class import IndependenceTest
 from mgcpy.independence_tests.mgc_utils.local_correlation import \
@@ -265,9 +265,9 @@ class MGC(IndependenceTest):
         p_value = _fast_pvalue(mgc_statistic, test_statistic_metadata)
 
         # The results are not statistically significant
-        #if p_value > 0.05:
-        #    warnings.warn("The p-value is greater than 0.05, implying that the results are not statistically significant.\n" +
-        #                  "Use results such as test_statistic and optimal_scale, with caution!")
+        if p_value > 0.05:
+            logging.warning("The p-value is greater than 0.05, implying that the results are not statistically significant.\n" +
+                          "Use results such as test_statistic and optimal_scale, with caution!")
 
         p_value_metadata = {"test_statistic": mgc_statistic,
                             "local_correlation_matrix": test_statistic_metadata["local_correlation_matrix"],

--- a/mgcpy/independence_tests/mgc.py
+++ b/mgcpy/independence_tests/mgc.py
@@ -265,9 +265,9 @@ class MGC(IndependenceTest):
         p_value = _fast_pvalue(mgc_statistic, test_statistic_metadata)
 
         # The results are not statistically significant
-        if p_value > 0.05:
-            warnings.warn("The p-value is greater than 0.05, implying that the results are not statistically significant.\n" +
-                          "Use results such as test_statistic and optimal_scale, with caution!")
+        #if p_value > 0.05:
+        #    warnings.warn("The p-value is greater than 0.05, implying that the results are not statistically significant.\n" +
+        #                  "Use results such as test_statistic and optimal_scale, with caution!")
 
         p_value_metadata = {"test_statistic": mgc_statistic,
                             "local_correlation_matrix": test_statistic_metadata["local_correlation_matrix"],

--- a/mgcpy/independence_tests/mgc.py
+++ b/mgcpy/independence_tests/mgc.py
@@ -1,8 +1,6 @@
 """
     **Main MGC Independence Test Module**
 """
-import logging
-
 from mgcpy.independence_tests.abstract_class import IndependenceTest
 from mgcpy.independence_tests.mgc_utils.local_correlation import \
     local_correlations
@@ -263,11 +261,6 @@ class MGC(IndependenceTest):
         '''
         mgc_statistic, test_statistic_metadata = self.test_statistic(matrix_X, matrix_Y, is_fast=True, fast_mgc_data={"sub_samples": sub_samples})
         p_value = _fast_pvalue(mgc_statistic, test_statistic_metadata)
-
-        # The results are not statistically significant
-        if p_value > 0.05:
-            logging.warning("The p-value is greater than 0.05, implying that the results are not statistically significant.\n" +
-                          "Use results such as test_statistic and optimal_scale, with caution!")
 
         p_value_metadata = {"test_statistic": mgc_statistic,
                             "local_correlation_matrix": test_statistic_metadata["local_correlation_matrix"],


### PR DESCRIPTION
I add an extra parameter to the metadata dictionary for p_value methods.